### PR TITLE
sublime-keymap pour OSX

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,3 @@
+[
+	{ "keys": ["super+k", "super+f"], "command": "indentxml" }
+]


### PR DESCRIPTION
Here is a .sublime-keymap for OSX as requested in Issue 1 (https://github.com/alek-sys/sublimetext_indentxml/issues/1). I could not make it work, I think this is because the command doesn't seem to work in the first place.
