### PR TITLE
Add Packages location for Mac and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@
 Indent plugin supports both Sublime Text 2 and Sublime Text 3
 
 ## Installation
-In Sublime Text 2 - just use [Package Control](http://wbond.net/sublime_packages/package_control) and search for "indentxml" plugin
-In Sublime Text 3 - clone project from [Github](https://github.com/alek-sys/sublimetext_indentxml.git) into Packages folder.
+ - In Sublime Text 2 - just use [Package Control](http://wbond.net/sublime_packages/package_control) and search for "indentxml" plugin
+ - In Sublime Text 3 - clone project from [Github](https://github.com/alek-sys/sublimetext_indentxml.git) into the user's Packages folder.
+    - On Mac, "~/Library/Application Support/Sublime Text 3/Packages/"
+    - On Windows, "C:\Users\\{user}\AppData\Roaming\Sublime Text 3\Packages"
 
 ## Feedback & Support
 Available on [Github](https://github.com/alek-sys/sublimetext_indentxml)


### PR DESCRIPTION
I had a little trouble getting this installed on my machine because I first tried to clone the repo into C:\Program Files\Sublime Text 3\Packages. I updated the README to include the file locations so others won't have the same confusion.
