### PR TITLE
Fix the missing '_' for macos key bindings

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,3 @@
 [
-	{ "keys": ["super+k", "super+f"], "command": "indentxml" }
+	{ "keys": ["super+k", "super+f"], "command": "indent_xml" }
 ]


### PR DESCRIPTION
This PR fixes the issue reported here: https://github.com/alek-sys/sublimetext_indentxml/issues/42

Many thanks for a really neat plugin!
